### PR TITLE
Keep xcodemake generated files in a hidden directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 ## User settings
 xcuserdata/
+.xcodemake/
 
 ## Obj-C/Swift specific
 *.hmap

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 xcodebuild output to generate a `Makefile` for an Xcode project.
 Invoke the script with the arguments you would normally provide to
 xcodebuild for a sucessfull build e.g. -scheme (target) and -sdk.
-Once the Makefile has been generated you can use the "make" command 
-for incremental builds which is generally considerably faster.
+Once the Makefile has been generated under `.xcodemake/`, the script uses
+it for incremental builds, which are generally considerably faster.
 Note however, `xcodemake` only recompiles program source changes,
 not resources or other binary aspects of an app bundle. You
 can use xcodebuild for that or Xocde's internal build system
@@ -31,8 +31,8 @@ system select "Other" and the executable from the file system
 directly in the scheme for the new target. If you encounter 
 errors revert to the default Xcode build system, build then
 try again. If you reorganise the files in the project the 
-script should recapture the xcodemake\*.log files in your 
-project root and the derived Makefile be regenerated.
+script should recapture the `xcodemake-*.log` files under `.xcodemake/`
+and regenerate the derived Makefile.
 
 If you replace `-sdk iphonesimulator` with `-sdk $(PLATFORM_NAME)`
 you can use this "make" based build system for real devices.
@@ -43,5 +43,12 @@ if you forget to do this are not very helpful. You need
 to select it directly as otherwise it creates an implict 
 dependency of the Xcode build and it will not be faster.
 
-xcodemake is a script. To install if you can use the instructions
-in [this issue](https://github.com/johnno1962/xcodemake/issues/3).
+## Installation
+
+Install `xcodemake` from the repository:
+
+```sh
+curl -O https://raw.githubusercontent.com/johnno1962/xcodemake/main/xcodemake
+chmod +x xcodemake
+sudo mv xcodemake /usr/local/bin/
+```

--- a/xcodemake
+++ b/xcodemake
@@ -28,7 +28,7 @@ my $hasConfiguration = $args =~ /-(?:config|configuration)\b/;
 my $hasScheme = $args =~ /-scheme\b/;
 $args .= " -configuration Debug" if !$hasConfiguration && !$hasScheme;
 
-my $variant = "$xcodebuild ARCHS=$archs $args";
+my $variant = "$xcodebuild ARCHS=$archs $args.";
 my $log = "$dir/xcodemake $args.log";
 my $builddb = ($ENV{OBJROOT}||'/tmp')."/XCBuildData/build.db";
 my $xcbuild = "/usr/bin/env -i '$xcodebuild' ARCHS=$archs $args";

--- a/xcodemake
+++ b/xcodemake
@@ -17,15 +17,19 @@
 use IO::File;
 use strict;
 
-my $log = "xcodemake @ARGV.log";
-my $make = "Makefile";
+my $dir = ".xcodemake";
+mkdir $dir unless -d $dir;
+my $make = "$dir/Makefile";
 
 my $xcodebuild = ($ENV{DEVELOPER_BIN_DIR}||'/usr/bin')."/xcodebuild";
 my $archs = $ENV{ARCHS}||'arm64';
 my $args = join ' ', map { "'$_'" } @ARGV;
-$args .= " -config Debug" if $args !~ /-config/;
+my $hasConfiguration = $args =~ /-(?:config|configuration)\b/;
+my $hasScheme = $args =~ /-scheme\b/;
+$args .= " -configuration Debug" if !$hasConfiguration && !$hasScheme;
 
-my $variant = "$xcodebuild ARCHS=$archs @ARGV";
+my $variant = "$xcodebuild ARCHS=$archs $args";
+my $log = "$dir/xcodemake $args.log";
 my $builddb = ($ENV{OBJROOT}||'/tmp')."/XCBuildData/build.db";
 my $xcbuild = "/usr/bin/env -i '$xcodebuild' ARCHS=$archs $args";
 my $EXIT_SUCCESS = 0;
@@ -39,9 +43,9 @@ $fileArg = "$notSpace+(?:\\\\.$notSpace*)*";
 captureXcodebuild() if ! -f $log || `find . -name project.pbxproj -newer '$log'`;
 
 # Regenerate Makefile (if script newer or different xcodebuild or arguments)
-generateMakefile() if ! -f $make || -M $0 < -M $make || !`grep ' $variant' Makefile`;
+generateMakefile() if ! -f $make || -M $0 < -M $make || !makefileMatchesVariant();
 
-exit $EXIT_SUCCESS if $EXIT_SUCCESS == system "make";
+exit $EXIT_SUCCESS if $EXIT_SUCCESS == system "make -f '$make'";
 
 rename $builddb, $builddb.".save";
 
@@ -49,7 +53,7 @@ rename $builddb, $builddb.".save";
 if ($EXIT_SUCCESS == system $xcbuild) {
     captureXcodebuild();
     generateMakefile();
-    exit $EXIT_SUCCESS if $EXIT_SUCCESS == system "make";
+    exit $EXIT_SUCCESS if $EXIT_SUCCESS == system "make -f '$make'";
 }
 
 rename $builddb.".save", $builddb;
@@ -72,6 +76,14 @@ sub captureXcodebuild {
     unlink $make;
     
     rename $builddb.".save", $builddb;
+}
+
+sub makefileMatchesVariant {
+    my $MAKE = IO::File->new("< $make") or return;
+    while (my $line = $MAKE->getline()) {
+        return 1 if index($line, " $variant") >= 0;
+    }
+    return;
 }
 
 sub generateMakefile {


### PR DESCRIPTION
## Summary

- store generated logs and Makefile under `.xcodemake/` instead of the project root
- avoid conflicting with an existing project `Makefile` by running `make -f .xcodemake/Makefile`
- improve configuration argument handling for `-configuration` and scheme-based builds
- document direct installation from the repository

## Why

The previous behavior could leave generated build files in the project root, including a generated `Makefile`, which is noisy and can conflict with projects that already use Make. This keeps xcodemake-generated files contained in a dedicated ignored directory and makes the script consistently read, regenerate, and run its generated Makefile from there.

## Validation

- `perl -c xcodemake`
- `git diff --check`