### PR TITLE
Support local Swift package changes

### DIFF
--- a/xcodemake
+++ b/xcodemake
@@ -16,7 +16,6 @@
 
 use IO::File;
 use Digest::MD5 qw(md5_hex);
-use File::Find qw(find);
 use strict;
 
 my $dir = ".xcodemake";
@@ -61,46 +60,15 @@ if (! -f $log || `find . -name project.pbxproj -newer '$log'`) {
 
 sub localSPMPackagesModified {
     my ($log) = @_;
-    my %pkgDirs;
-    my $modified;
-    find({
-        no_chdir => 1,
-        wanted => sub {
-            return if $modified;
-            if (-d $_ && shouldPruneSPMPath($_)) {
-                $File::Find::prune = 1;
-                return;
-            }
-            $pkgDirs{$_} = 1 if -d $_ && -f "$_/Package.swift";
-            return unless -f $_;
-            my $pkgDir = localSPMPackageDirForFile($_, \%pkgDirs) or return;
-            return unless m{(?:^|/)Package\.swift$} || localSPMFileCanAffectBuild($_, $pkgDir);
-            $modified = 1 if -M $_ < -M $log;
-        },
-    }, ".");
-    return $modified;
-}
-
-sub shouldPruneSPMPath {
-    return $_[0] =~ m{(?:^|/)(?:\.build|\.git|\.swiftpm|\.xcodemake)(?:/|$)};
-}
-
-sub localSPMPackageDirForFile {
-    my ($file, $pkgDirs) = @_;
-    $file =~ s{/[^/]+$}{};
-    while (1) {
-        return $file if $pkgDirs->{$file};
-        last if $file eq ".";
-        $file =~ s{/[^/]+$}{} or $file = ".";
+    for my $package (localSPMPackageDirs()) {
+        return 1 if `find '$package' \\( -name .build -o -name .git -o -name .swiftpm -o -name .xcodemake \\) -prune -o -type f -newer '$log' -print -quit`;
     }
     return;
 }
 
-sub localSPMFileCanAffectBuild {
-    my ($file, $pkgDir) = @_;
-    return 1 if $file =~ m{^\Q$pkgDir\E/(?:Sources|Tests|Plugins|Snippets|Examples|include)/};
-    return 1 if $file =~ /\.(?:swift|c|cc|cpp|cxx|m|mm|h|hh|hpp|hxx|modulemap|metal|xib|storyboard|strings|stringsdict|plist|json|png|jpe?g|gif|pdf|svg|mp3|mp4|wav|caf|aiff|mov|ttf|otf|data|dat|mlmodel|xcdatamodeld?)$/i;
-    return 0;
+sub localSPMPackageDirs {
+    return map { chomp; s{/Package\.swift$}{}; $_ }
+        `find . \\( -name .build -o -name .git -o -name .swiftpm -o -name .xcodemake \\) -prune -o -name Package.swift -print`;
 }
 
 sub captureXcodebuildIncremental {

--- a/xcodemake
+++ b/xcodemake
@@ -16,6 +16,7 @@
 
 use IO::File;
 use Digest::MD5 qw(md5_hex);
+use File::Find qw(find);
 use strict;
 
 my $dir = ".xcodemake";
@@ -52,7 +53,67 @@ my $notSpace = "[^\\\\\\s]";
 $fileArg = "$notSpace+(?:\\\\.$notSpace*)*";
 
 # Recapture xcodebuild output if paramaters change or project has been edited
-captureXcodebuild() if ! -f $log || `find . -name project.pbxproj -newer '$log'`;
+if (! -f $log || `find . -name project.pbxproj -newer '$log'`) {
+    captureXcodebuild();
+} elsif (localSPMPackagesModified($log)) {
+    captureXcodebuildIncremental();
+}
+
+sub localSPMPackagesModified {
+    my ($log) = @_;
+    my %pkgDirs;
+    my $modified;
+    find({
+        no_chdir => 1,
+        wanted => sub {
+            return if $modified;
+            if (-d $_ && shouldPruneSPMPath($_)) {
+                $File::Find::prune = 1;
+                return;
+            }
+            $pkgDirs{$_} = 1 if -d $_ && -f "$_/Package.swift";
+            return unless -f $_;
+            my $pkgDir = localSPMPackageDirForFile($_, \%pkgDirs) or return;
+            return unless m{(?:^|/)Package\.swift$} || localSPMFileCanAffectBuild($_, $pkgDir);
+            $modified = 1 if -M $_ < -M $log;
+        },
+    }, ".");
+    return $modified;
+}
+
+sub shouldPruneSPMPath {
+    return $_[0] =~ m{(?:^|/)(?:\.build|\.git|\.swiftpm|\.xcodemake)(?:/|$)};
+}
+
+sub localSPMPackageDirForFile {
+    my ($file, $pkgDirs) = @_;
+    $file =~ s{/[^/]+$}{};
+    while (1) {
+        return $file if $pkgDirs->{$file};
+        last if $file eq ".";
+        $file =~ s{/[^/]+$}{} or $file = ".";
+    }
+    return;
+}
+
+sub localSPMFileCanAffectBuild {
+    my ($file, $pkgDir) = @_;
+    return 1 if $file =~ m{^\Q$pkgDir\E/(?:Sources|Tests|Plugins|Snippets|Examples|include)/};
+    return 1 if $file =~ /\.(?:swift|c|cc|cpp|cxx|m|mm|h|hh|hpp|hxx|modulemap|metal|xib|storyboard|strings|stringsdict|plist|json|png|jpe?g|gif|pdf|svg|mp3|mp4|wav|caf|aiff|mov|ttf|otf|data|dat|mlmodel|xcdatamodeld?)$/i;
+    return 0;
+}
+
+sub captureXcodebuildIncremental {
+    rename $builddb, $builddb.".save";
+    my $command = "$xcbuild 2>&1 | tee '$log'";
+    warn "Executing incremental: $command\n";
+    if ($EXIT_SUCCESS != system $command) {
+        unlink $log;
+        exit !$EXIT_SUCCESS;
+    }
+    unlink $make;
+    rename $builddb.".save", $builddb;
+}
 
 # Regenerate Makefile (if script newer or different xcodebuild or arguments)
 generateMakefile() if ! -f $make || -M $0 < -M $make || !makefileMatchesVariant();

--- a/xcodemake
+++ b/xcodemake
@@ -45,6 +45,7 @@ my $log = "$dir/$logTag$logSuffix";
 my $builddb = ($ENV{OBJROOT}||'/tmp')."/XCBuildData/build.db";
 my $xcbuild = "/usr/bin/env -i '$xcodebuild' ARCHS=$archs $args";
 my $EXIT_SUCCESS = 0;
+my $INCREMENTAL = 1;
 my ($LOG, $fileArg);
 
 # regex for file path argument
@@ -55,7 +56,7 @@ $fileArg = "$notSpace+(?:\\\\.$notSpace*)*";
 if (! -f $log || `find . -name project.pbxproj -newer '$log'`) {
     captureXcodebuild();
 } elsif (localSPMPackagesModified($log)) {
-    captureXcodebuildIncremental();
+    captureXcodebuild($INCREMENTAL);
 }
 
 sub localSPMPackagesModified {
@@ -69,18 +70,6 @@ sub localSPMPackagesModified {
 sub localSPMPackageDirs {
     return map { chomp; s{/Package\.swift$}{}; $_ }
         `find . \\( -name .build -o -name .git -o -name .swiftpm -o -name .xcodemake \\) -prune -o -name Package.swift -print`;
-}
-
-sub captureXcodebuildIncremental {
-    rename $builddb, $builddb.".save";
-    my $command = "$xcbuild 2>&1 | tee '$log'";
-    warn "Executing incremental: $command\n";
-    if ($EXIT_SUCCESS != system $command) {
-        unlink $log;
-        exit !$EXIT_SUCCESS;
-    }
-    unlink $make;
-    rename $builddb.".save", $builddb;
 }
 
 # Regenerate Makefile (if script newer or different xcodebuild or arguments)
@@ -101,6 +90,7 @@ rename $builddb.".save", $builddb;
 exit !$EXIT_SUCCESS;
 
 sub captureXcodebuild {
+    my ($incremental) = @_;
     # Move Xcode's build database to one side to
     # be able to use xcodebuild inside a scheme.
     rename $builddb, $builddb.".save";
@@ -108,7 +98,7 @@ sub captureXcodebuild {
     if (my ($bundle) = $variant =~ /-resultBundlePath ($fileArg)/) {
         $xcbuild = "rm -rf '$bundle'; $xcbuild";
     }
-    my $command = "$xcbuild clean; $xcbuild 2>&1 | tee '$log'";
+    my $command = ($incremental ? "" : "$xcbuild clean; ") . "$xcbuild 2>&1 | tee '$log'";
     warn "Executing: $command\n";
     if ($EXIT_SUCCESS != system $command) {
         unlink $log;


### PR DESCRIPTION
## Summary

Makes `xcodemake` recapture xcodebuild output when files from a local Swift package change.

## Why

`xcodemake` generates a Makefile from captured `xcodebuild` output, then uses that Makefile for faster rebuilds. This works well for source files that are already represented in the generated Makefile, but local Swift packages can fall through that model.

For example, with a project layout like this:

```text
MyApp/
  MyApp.xcodeproj/
    project.pbxproj
  App/
    ViewController.swift
  LocalPackages/
    DesignSystem/
      Package.swift
      Sources/
        DesignSystem/
          Button.swift
      Resources/
        colors.json
```

If `LocalPackages/DesignSystem/Sources/DesignSystem/Button.swift` or a package resource changes, the Xcode project file does not change. The existing project-file timestamp check therefore does not trigger a new xcodebuild capture, and `xcodemake` can keep building from stale captured output.

This adds a lightweight local Swift package timestamp check using `find -newer` so those changes trigger an incremental recapture.

## What Changed

- Recursively discovers local Swift packages by finding `Package.swift` files under the project.
- Uses `find -newer` to detect changed files under those package directories.
- Ignores `.build`, `.git`, `.swiftpm`, and `.xcodemake` to avoid cache noise.
- Runs an incremental xcodebuild recapture without `clean`, then removes the generated Makefile so it is regenerated from the updated log.

## Validation

- Ran `perl -c xcodemake`.
